### PR TITLE
Fix Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ INCFLAGS=-I. -Ivendor
 DEPFLAGS=-MD -MP
 WARNFLAGS=$(addprefix -W,all error no-sign-compare)
 EXTRAFLAGS=-fno-deduce-init-list
-CPPFLAGS=$(INCFLAGS) $(DEPFLAGS) $(WARNFLAGS) $(EXTRAFLAGS)
-CXXFLAGS=-std=c++0x
+CPPFLAGS+=$(INCFLAGS) $(DEPFLAGS) $(WARNFLAGS) $(EXTRAFLAGS)
+CXXFLAGS+=-std=c++0x
 SRC=$(wildcard *.cpp)
 
 .PHONY : all


### PR DESCRIPTION
Two issues with the current Makefile:
- Parallel builds often fail.  Tests run while pd is being built.
- Some environmental variables (e.g. `CXXFLAGS`) are not inherited.  This makes it more difficult to integrate protodata with other environments (e.g. distribution packagers).
