### PR TITLE
Fix V629 warning from PVS-Studio Static Analyzer

### DIFF
--- a/write.h
+++ b/write.h
@@ -109,7 +109,7 @@ void write_integer
           uint64_t buffer;
           if (promoted < 0) {
             buffer = -promoted;
-            buffer = (~buffer + 1) & ((1u << state.width) - 1);
+            buffer = (~buffer + 1) & ((1ull << state.width) - 1);
           } else {
             buffer = promoted;
           }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
Consider inspecting the '1u << state.width' expression.
Bit shifting of the 32-bit value with a subsequent
expansion to the 64-bit type.