### PR TITLE
Handle escaped characters correctly

### DIFF
--- a/parse.cpp
+++ b/parse.cpp
@@ -265,6 +265,7 @@ void parse_internal(std::istream& input, Interpreter& interpreter,
         }
         terms.push_back(Term::write(value));
         ++here;
+        state = STRING;
       }
     }
     interpreter.run(terms);

--- a/test/escape-characters.out.expect
+++ b/test/escape-characters.out.expect
@@ -1,0 +1,2 @@
+	"Hello \ world"
+!

--- a/test/escape-characters.pd
+++ b/test/escape-characters.pd
@@ -1,0 +1,1 @@
+utf8 "\t\"Hello \\ world\"\n\e!"


### PR DESCRIPTION
Modifies escaped character handling behaviour to mark characters after the first escaped character as plain string characters.

I.e. before, was parsing `string "a\nb"` as both `n` and `b` being escaped characters.