### PR TITLE
Add function parsing

### DIFF
--- a/Interpreter.cpp
+++ b/Interpreter.cpp
@@ -1,6 +1,7 @@
 #include <Interpreter.h>
 
 #include <write.h>
+#include <fstream>
 
 Interpreter::Interpreter(std::ostream& output)
   : output(output) {
@@ -12,6 +13,10 @@ Interpreter::State::State() :
   endianness(Term::NATIVE),
   signedness(Term::UNSIGNED),
   format(Term::INTEGER) {}
+
+Interpreter::FunctionState::FunctionState(Term::Function function)
+: function(function),
+  parameters() {}
 
 void Interpreter::run(const std::vector<Term>& terms) {
   for (auto term : terms) {
@@ -30,7 +35,17 @@ void Interpreter::run(const std::vector<Term>& terms) {
       write_integer(state.top(), term.value.as_signed, output);
       break;
     case Term::WRITE_UNSIGNED:
-      write_integer(state.top(), term.value.as_unsigned, output);
+      if (functionState.empty()) {
+        write_integer(state.top(), term.value.as_unsigned, output);
+      } else {
+        auto& parameters = functionState.top().parameters;
+
+        if (parameters.empty()) {
+          parameters.emplace_back("");
+        }
+
+        parameters.back() += static_cast<char>(term.value.as_unsigned);
+      }
       break;
     case Term::WRITE_DOUBLE:
       write_float(state.top(), term.value.as_double, output);
@@ -47,6 +62,57 @@ void Interpreter::run(const std::vector<Term>& terms) {
     case Term::SET_FORMAT:
       state.top().format = term.value.as_format;
       break;
+    case Term::FUNCTION:
+      functionState.push(FunctionState(term.value.as_function));
+      break;
+    case Term::NEXT_PARAMETER:
+      functionState.top().parameters.emplace_back("");
+      break;
+    case Term::FUNCTION_CLOSE_BRACKET: {
+      const auto function = functionState.top();
+      functionState.pop();
+      switch (function.function) {
+        case Term::Function::FILE: {
+          const auto parameters = function.parameters;
+
+          if (parameters.empty()) {
+            throw std::runtime_error(
+              "Expected a filename argument to file() function.\n"
+            );
+          }
+          if (parameters.size() > 1) {
+            throw std::runtime_error(
+              "Only expected a single filename argument to file() function.\n"
+            );
+          }
+          std::ifstream file(parameters[0], std::ios::binary | std::ios::in);
+          if (!file) {
+            throw std::runtime_error(
+              "File '" + parameters[0] + "' not found.\n"
+            );
+          }
+
+          file.seekg(0, std::ios::end);
+          const long fileSize = file.tellg();
+          file.seekg(0, std::ios::beg);
+          std::vector<char> fileData(fileSize);
+          file.read(fileData.data(), fileSize);
+          write_binary(fileData, output);
+          break;
+        }
+        default:
+          throw std::runtime_error(
+            "Unexpected function found: "
+            + std::to_string(term.value.as_function)
+            + ".\n"
+          );
+      }
+      break;
+    }
+    default:
+      throw std::runtime_error(
+        "Unexpected state found: " + std::to_string(term.type) + "\n"
+      );
     }
   }
 }

--- a/Interpreter.h
+++ b/Interpreter.h
@@ -18,9 +18,17 @@ public:
     Term::Signedness signedness;
     Term::Format format;
   };
+
+  struct FunctionState {
+      FunctionState(Term::Function function);
+
+      Term::Function function;
+      std::vector<std::string> parameters;
+  };
 private:
   Stream output;
   std::stack<State> state;
+  std::stack<FunctionState> functionState;
 };
 
 #endif

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ The default endianness is `native`.
 
 **Endianness affects *only* 16-, 32-, and 64-bit types!**†
 
+### Importing Other Files
+
+* `file("filename")`
+
+The file function reads the named file into the output, in-line.
+
 ### Compiler State
 
 The compiler state consists of the current type and endianness. It can be saved and restored with the following commands:

--- a/Term.cpp
+++ b/Term.cpp
@@ -20,12 +20,18 @@ Term::Term(const Format format) : type(SET_FORMAT) {
   value.as_format = format;
 }
 
+Term::Term(const Function function) : type(FUNCTION) {
+  value.as_function = function;
+}
+
 Term::Term(const Type type, const void* const source = 0) : type(type) {
   switch (type) {
   case NOOP:
     break;
   case PUSH:
   case POP:
+  case FUNCTION_CLOSE_BRACKET:
+  case NEXT_PARAMETER:
     break;
   case WRITE_SIGNED:
     value.as_signed = *static_cast<const Signed*>(source);
@@ -47,6 +53,14 @@ Term Term::push() {
 
 Term Term::pop() {
   return Term(POP);
+}
+
+Term Term::close_bracket() {
+  return Term(FUNCTION_CLOSE_BRACKET);
+}
+
+Term Term::next_parameter() {
+  return Term(NEXT_PARAMETER);
 }
 
 Term Term::write(const uint64_t value) {

--- a/Term.h
+++ b/Term.h
@@ -2,6 +2,7 @@
 #define PROTODATA_TOKEN_H
 
 #include <cstdint>
+#include <string>
 
 class Term {
 public:
@@ -19,10 +20,16 @@ public:
     FLOAT,
     UNICODE,
   };
+  enum Function {
+    FILE,
+  };
   enum Type {
     NOOP,
     PUSH,
     POP,
+    FUNCTION,
+    FUNCTION_CLOSE_BRACKET,
+    NEXT_PARAMETER,
     WRITE_SIGNED,
     WRITE_UNSIGNED,
     WRITE_DOUBLE,
@@ -40,8 +47,11 @@ public:
   Term(Signedness);
   Term(Width);
   Term(Format);
+  Term(Function);
   static Term push();
   static Term pop();
+  static Term close_bracket();
+  static Term next_parameter();
   static Term write(uint64_t);
   static Term write(int64_t);
   static Term write(double);
@@ -53,6 +63,7 @@ public:
     Signedness as_signedness;
     Width as_width;
     Format as_format;
+    Function as_function;
   };
   Type type;
   Value value;

--- a/test/file-include.data
+++ b/test/file-include.data
@@ -1,0 +1,1 @@
+Raw data imported from file.

--- a/test/file-include.out.expect
+++ b/test/file-include.out.expect
@@ -1,0 +1,1 @@
+Raw data imported from file.

--- a/test/file-include.pd
+++ b/test/file-include.pd
@@ -1,0 +1,1 @@
+file("file-include.data")

--- a/write.h
+++ b/write.h
@@ -170,6 +170,11 @@ void write_float
   }
 }
 
+template<class T>
+void write_binary(const std::vector<T>& data, Stream& output) {
+  output.write(data.begin(), data.end());
+}
+
 // Conversion via pointer to character type is, to my
 // knowledge, the only way of detecting endianness that is
 // required to work by the C++ standard.


### PR DESCRIPTION
Not sure if this is something upstream would find useful, but I've added basic function parsing, and a function to import a binary file's data into the output stream.

This allows copying in binary blobs into the output, without needing to split up the protodata into sections which are `cat`ed together.